### PR TITLE
Add `WorkspaceMember` to allow non root kernel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,10 @@ pub enum WorkspaceMember {
 ///
 /// Returns the manifest path of the bootloader, i.e. the path to the Cargo.toml on the file
 /// system.
-pub fn locate_bootloader(dependency_name: &str, member: WorkspaceMember) -> Result<PathBuf, LocateError> {
+pub fn locate_bootloader(
+    dependency_name: &str,
+    member: WorkspaceMember,
+) -> Result<PathBuf, LocateError> {
     let metadata = metadata()?;
 
     let member_resolve = match member {
@@ -33,7 +36,8 @@ pub fn locate_bootloader(dependency_name: &str, member: WorkspaceMember) -> Resu
         WorkspaceMember::Name(member) => metadata["resolve"]["nodes"]
             .members()
             .find(|r| {
-                r["id"].as_str()
+                r["id"]
+                    .as_str()
                     .map(|s| s.starts_with(&member))
                     .unwrap_or_default()
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 use std::{convert, fmt, io, path::PathBuf, process::Command, string};
 
 /// The type of workspace member to select
+#[derive(Debug)]
 pub enum WorkspaceMember {
     /// The root package of the workspace
     Root,


### PR DESCRIPTION
Add `WorkspaceMember` to select non root packages, I see that #2 also attempts to solve this problem but relies on a hardcoded path to the manifest. This pr allows selecting a package based on its name so you can have a top level workspace with a kernel as a member.