### PR TITLE
Cargo: Move from json to serde_json crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-json = "0.12.4"
+serde_json = "1.0.108"
 
 [package.metadata.release]
 no-dev-version = true


### PR DESCRIPTION
Since the json crate is not managed anymore, it would be beneficial to move from json crate and use serde_json instead for parsing json strings.